### PR TITLE
Add classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,16 @@ setup(
     packages=[
         'ansicolor',
     ],
-
+    classifiers=[
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+    ],
     # don't install as zipped egg
     zip_safe=False,
 )


### PR DESCRIPTION
Classifiers are used by PyPI (and http://caniusepython3.com) to determine what packages are Python 3 compatible. By including them, you signal that you support Python 3.

As an added bonus, you get to signal that you support PyPy!
