### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,10 @@ ansicolor
 .. image:: https://travis-ci.org/numerodix/ansicolor.png?branch=master
     :target: https://travis-ci.org/numerodix/ansicolor
 
-.. image:: https://pypip.in/wheel/ansicolor/badge.png
+.. image:: https://img.shields.io/pypi/wheel/ansicolor.svg
     :target: https://pypi.python.org/pypi/ansicolor/
 
-.. image:: https://pypip.in/license/ansicolor/badge.png
+.. image:: https://img.shields.io/pypi/l/ansicolor.svg
         :target: https://pypi.python.org/pypi/ansicolor/
 
 Python version support: CPython 2.6, 2.7, 3.2, 3.3, 3.4 and PyPy.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ansicolor))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ansicolor`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.